### PR TITLE
Logging correspondence party

### DIFF
--- a/src/main/java/no/fint/sikri/data/noark/journalpost/JournalpostFactory.java
+++ b/src/main/java/no/fint/sikri/data/noark/journalpost/JournalpostFactory.java
@@ -108,6 +108,9 @@ public class JournalpostFactory {
             }
             return korrespondansepartResource;
         }).collect(Collectors.toList()));
+        log.debug("There are currently {} korrespondansepart(s) on this journalpost aka number {}.",
+                journalpost.getKorrespondansepart().size(), journalpost.getJournalPostnummer());
+
         journalpost.setMerknad(merknadService.getRemarkForRegistryEntry(identity, result.getId().toString()));
 
         journalpost.setDokumentbeskrivelse(dokumentbeskrivelseService.queryForJournalpost(identity,

--- a/src/main/java/no/fint/sikri/data/noark/journalpost/JournalpostFactory.java
+++ b/src/main/java/no/fint/sikri/data/noark/journalpost/JournalpostFactory.java
@@ -78,7 +78,6 @@ public class JournalpostFactory {
         journalpost.setJournalPostnummer(Long.valueOf(result.getDocumentNumber()));
         // TODO journalpost.setJournalSekvensnummer(Long.valueOf(result.getSequenceNumber()));
 
-
         // FIXME: 2019-05-08 check for empty
         journalpost.setReferanseArkivDel(Collections.emptyList());
 

--- a/src/main/java/no/fint/sikri/data/noark/korrespondansepart/KorrespondansepartFactory.java
+++ b/src/main/java/no/fint/sikri/data/noark/korrespondansepart/KorrespondansepartFactory.java
@@ -116,7 +116,7 @@ public class KorrespondansepartFactory {
                 .ifPresent(output::setTwoLetterCountryCode);
 
         String[] expectedContactTypes = skipInternalContacts ? new String[]{"EA", "EM", "EK"} : new String[]{"EA", "EM", "EK", "IA", "IM", "IK"};
-        log.debug("The boolean skipInternalContacs is set to {} resulting in these expected contact types: {}",
+        log.debug("The boolean skipInternalContacts is set to {} resulting in these expected contact types: {}",
                 skipInternalContacts, expectedContactTypes);
 
         optionalValue(input.getKorrespondanseparttype()).map(List::stream)
@@ -127,6 +127,7 @@ public class KorrespondansepartFactory {
                 .filter(s -> StringUtils.equalsAny(s, expectedContactTypes))
                 .findFirst()
                 .ifPresent(type -> {
+                    log.debug("Currently giving the type '{}' some TLC.", type);
                     output.setCopyRecipient(false);
                     output.setIsRecipient(false);
                     output.setIsResponsible(false);

--- a/src/main/java/no/fint/sikri/data/noark/korrespondansepart/KorrespondansepartFactory.java
+++ b/src/main/java/no/fint/sikri/data/noark/korrespondansepart/KorrespondansepartFactory.java
@@ -67,6 +67,9 @@ public class KorrespondansepartFactory {
 
         output.addKorrespondanseparttype(Link.with(KorrespondansepartType.class, "systemid", recipientType));
 
+        log.debug("AdministrativeUnitId: {}, OfficerNameId: {}, IsCopyRecipient: {}, IsRecipient: {}",
+                input.getAdministrativeUnitId(), input.getOfficerNameId(), input.isCopyRecipient(), input.isIsRecipient());
+
         log.debug("Based on the input, the recipientType is set to {}, and the KorrespondansepartType to: {}. Size: {}",
                 recipientType, output.getKorrespondanseparttype(), output.getKorrespondanseparttype().size());
 

--- a/src/main/java/no/fint/sikri/data/noark/korrespondansepart/KorrespondansepartFactory.java
+++ b/src/main/java/no/fint/sikri/data/noark/korrespondansepart/KorrespondansepartFactory.java
@@ -67,8 +67,8 @@ public class KorrespondansepartFactory {
 
         output.addKorrespondanseparttype(Link.with(KorrespondansepartType.class, "systemid", recipientType));
 
-        log.debug("Based on the input, the recipientType is set to '{}, and the KorrespondansepartType to: {}'",
-                recipientType, output.getKorrespondanseparttype());
+        log.debug("Based on the input, the recipientType is set to {}, and the KorrespondansepartType to: {}. Size: {}",
+                recipientType, output.getKorrespondanseparttype(), output.getKorrespondanseparttype().size());
 
         return output;
     }

--- a/src/main/java/no/fint/sikri/data/noark/korrespondansepart/KorrespondansepartFactory.java
+++ b/src/main/java/no/fint/sikri/data/noark/korrespondansepart/KorrespondansepartFactory.java
@@ -69,7 +69,6 @@ public class KorrespondansepartFactory {
 
         log.debug("AdministrativeUnitId: {}, OfficerNameId: {}, IsCopyRecipient: {}, IsRecipient: {}",
                 input.getAdministrativeUnitId(), input.getOfficerNameId(), input.isCopyRecipient(), input.isIsRecipient());
-
         log.debug("Based on the input, the recipientType is set to {}, and the KorrespondansepartType to: {}. Size: {}",
                 recipientType, output.getKorrespondanseparttype(), output.getKorrespondanseparttype().size());
 
@@ -127,7 +126,7 @@ public class KorrespondansepartFactory {
                 .filter(s -> StringUtils.equalsAny(s, expectedContactTypes))
                 .findFirst()
                 .ifPresent(type -> {
-                    log.debug("Currently giving the type '{}' some TLC.", type);
+                    log.trace("Currently giving the type '{}' some TLC.", type);
                     output.setCopyRecipient(false);
                     output.setIsRecipient(false);
                     output.setIsResponsible(false);
@@ -149,9 +148,11 @@ public class KorrespondansepartFactory {
                     }
                 });
 
-        log.debug("About to return the SenderRecipientType. Is it at recipient? Answer: {}. OfficerNameId: {}, AdministrativeUnitId: {}.",
+        log.debug("About to return the SenderRecipientType. IsRecipient: {}, OfficerNameId: {}, AdministrativeUnitId: {}.",
                 output.isIsRecipient(), output.getOfficerNameId(), output.getAdministrativeUnitId());
-        log.debug("The SenderRecipientType was made based on this input (KorrespondansepartResource): {}", input.getKorrespondanseparttype());
+        log.debug("The SenderRecipientType was made based on this input (KorrespondansepartResource): {}",
+                input.getKorrespondanseparttype());
+
         return output;
     }
 }

--- a/src/main/java/no/fint/sikri/data/noark/korrespondansepart/KorrespondansepartFactory.java
+++ b/src/main/java/no/fint/sikri/data/noark/korrespondansepart/KorrespondansepartFactory.java
@@ -67,6 +67,9 @@ public class KorrespondansepartFactory {
 
         output.addKorrespondanseparttype(Link.with(KorrespondansepartType.class, "systemid", recipientType));
 
+        log.debug("Based on the input, the recipientType is set to '{}, and the KorrespondansepartType to: {}'",
+                recipientType, output.getKorrespondanseparttype());
+
         return output;
     }
 

--- a/src/main/java/no/fint/sikri/data/noark/korrespondansepart/KorrespondansepartFactory.java
+++ b/src/main/java/no/fint/sikri/data/noark/korrespondansepart/KorrespondansepartFactory.java
@@ -1,5 +1,6 @@
 package no.fint.sikri.data.noark.korrespondansepart;
 
+import lombok.extern.slf4j.Slf4j;
 import no.fint.arkiv.sikri.oms.SenderRecipientType;
 import no.fint.model.arkiv.kodeverk.KorrespondansepartType;
 import no.fint.model.felles.kodeverk.iso.Landkode;
@@ -18,6 +19,7 @@ import java.util.stream.Stream;
 import static no.fint.sikri.data.utilities.SikriUtils.optionalValue;
 
 @Service
+@Slf4j
 public class KorrespondansepartFactory {
 
     @Value("${fint.sikri.skip-internal-contacts:false}")
@@ -108,6 +110,8 @@ public class KorrespondansepartFactory {
                 .ifPresent(output::setTwoLetterCountryCode);
 
         String[] expectedContactTypes = skipInternalContacts ? new String[]{"EA", "EM", "EK"} : new String[]{"EA", "EM", "EK", "IA", "IM", "IK"};
+        log.debug("The boolean skipInternalContacs is set to {} resulting in these expected contact types: {}",
+                skipInternalContacts, expectedContactTypes);
 
         optionalValue(input.getKorrespondanseparttype()).map(List::stream)
                 .orElseGet(Stream::empty)
@@ -138,6 +142,8 @@ public class KorrespondansepartFactory {
                     }
                 });
 
+        log.debug("About to return the SenderRecipientType. Is it at recipient? Answer: {}. OfficerNameId: {}, AdministrativeUnitId: {}",
+                output.isIsRecipient(), output.getOfficerNameId(), output.getAdministrativeUnitId());
         return output;
     }
 }

--- a/src/main/java/no/fint/sikri/data/noark/korrespondansepart/KorrespondansepartFactory.java
+++ b/src/main/java/no/fint/sikri/data/noark/korrespondansepart/KorrespondansepartFactory.java
@@ -148,8 +148,9 @@ public class KorrespondansepartFactory {
                     }
                 });
 
-        log.debug("About to return the SenderRecipientType. Is it at recipient? Answer: {}. OfficerNameId: {}, AdministrativeUnitId: {}",
+        log.debug("About to return the SenderRecipientType. Is it at recipient? Answer: {}. OfficerNameId: {}, AdministrativeUnitId: {}.",
                 output.isIsRecipient(), output.getOfficerNameId(), output.getAdministrativeUnitId());
+        log.debug("The SenderRecipientType was made based on this input (KorrespondansepartResource): {}", input.getKorrespondanseparttype());
         return output;
     }
 }


### PR DESCRIPTION
Added when dealing with internal contacts in Vestland county. Turn it on using logging level debug or trace. May be removed without further notice.